### PR TITLE
DAT-20255 Ansible: Permission Issue to github-actions[bot]

### DIFF
--- a/.github/workflows/deploy-role.yml
+++ b/.github/workflows/deploy-role.yml
@@ -56,11 +56,6 @@ jobs:
         with:
           repository: liquibase/liquibase-ansible
           token: ${{ steps.get-token.outputs.token }}
-
-      - name: Configure Git
-        run: |
-          git config --local user.email "64099989+liquibot@users.noreply.github.com"
-          git config --local user.name "liquibot"
                 
       - name: Update main.yml
         if: ${{ inputs.dry_run == false }}

--- a/.github/workflows/deploy-role.yml
+++ b/.github/workflows/deploy-role.yml
@@ -56,6 +56,11 @@ jobs:
         with:
           repository: liquibase/liquibase-ansible
           token: ${{ steps.get-token.outputs.token }}
+
+      - name: Configure Git
+        run: |
+          git config --local user.email "64099989+liquibot@users.noreply.github.com"
+          git config --local user.name "liquibot"
                 
       - name: Update main.yml
         if: ${{ inputs.dry_run == false }}

--- a/.github/workflows/deploy-role.yml
+++ b/.github/workflows/deploy-role.yml
@@ -47,11 +47,15 @@ jobs:
         with:
           repository: liquibase/liquibase-ansible
 
-      - name: Configure Git
-        run: |
-          git config --local user.email "64099989+liquibot@users.noreply.github.com"
-          git config --local user.name "liquibot"
-
+      - name: Get GitHub App token
+        id: get-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.LIQUIBASE_GITHUB_APP_ID }}
+          private-key: ${{ secrets.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          permission-contents: write
+                
       - name: Update main.yml
         if: ${{ inputs.dry_run == false }}
         env:
@@ -73,7 +77,7 @@ jobs:
             echo "No changes to commit."
           else
             git commit -m "Update liquibase.version to ${{ inputs.version }}"
-            git remote set-url origin https://liquibot:${{ secrets.GITHUB_TOKEN }}@github.com/liquibase/liquibase-ansible.git
+            git remote set-url origin https://x-access-token:${{ steps.get-token.outputs.token }}@github.com/liquibase/liquibase-ansible.git
             if [[ "${{ inputs.dry_run }}" == false ]]; then
               git push
             else

--- a/.github/workflows/deploy-role.yml
+++ b/.github/workflows/deploy-role.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Update main.yml
         if: ${{ inputs.dry_run == false }}
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.get-token.outputs.token }}
         run: |
           sed -i "s/liquibase_ver: .*/liquibase_ver: ${{ inputs.version }}/" defaults/main.yml
           if [[ "${{ inputs.dry_run }}" == false ]]; then

--- a/.github/workflows/deploy-role.yml
+++ b/.github/workflows/deploy-role.yml
@@ -84,7 +84,7 @@ jobs:
             git commit -m "Update liquibase.version to ${{ inputs.version }}"
             git remote set-url origin https://x-access-token:${{ steps.get-token.outputs.token }}@github.com/liquibase/liquibase-ansible.git
             if [[ "${{ inputs.dry_run }}" == false ]]; then
-              git push "https://${{ steps.get-token.outputs.token }}@github.com/liquibase/liquibase-ansible.git" HEAD:main
+              git push "https://x-access-token:${{ steps.get-token.outputs.token }}@github.com/liquibase/liquibase-ansible.git" HEAD:main
             else
                 echo "Dry run mode: changes have not been pushed."
             fi

--- a/.github/workflows/deploy-role.yml
+++ b/.github/workflows/deploy-role.yml
@@ -55,6 +55,11 @@ jobs:
           private-key: ${{ secrets.LIQUIBASE_GITHUB_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           permission-contents: write
+
+      - name: Configure Git
+        run: |
+          git config --local user.email "64099989+liquibot@users.noreply.github.com"
+          git config --local user.name "liquibot"
                 
       - name: Update main.yml
         if: ${{ inputs.dry_run == false }}

--- a/.github/workflows/deploy-role.yml
+++ b/.github/workflows/deploy-role.yml
@@ -42,11 +42,6 @@ jobs:
       LIQUIBASE_VERSION: ${{ inputs.version }}
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          repository: liquibase/liquibase-ansible
-
       - name: Get GitHub App token
         id: get-token
         uses: actions/create-github-app-token@v2
@@ -56,6 +51,12 @@ jobs:
           owner: ${{ github.repository_owner }}
           permission-contents: write
 
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          repository: liquibase/liquibase-ansible
+          token: ${{ steps.get-token.outputs.token }}
+
       - name: Configure Git
         run: |
           git config --local user.email "64099989+liquibot@users.noreply.github.com"
@@ -63,8 +64,6 @@ jobs:
                 
       - name: Update main.yml
         if: ${{ inputs.dry_run == false }}
-        env:
-          GH_TOKEN: ${{ steps.get-token.outputs.token }}
         run: |
           sed -i "s/liquibase_ver: .*/liquibase_ver: ${{ inputs.version }}/" defaults/main.yml
           if [[ "${{ inputs.dry_run }}" == false ]]; then
@@ -82,9 +81,8 @@ jobs:
             echo "No changes to commit."
           else
             git commit -m "Update liquibase.version to ${{ inputs.version }}"
-            git remote set-url origin https://x-access-token:${{ steps.get-token.outputs.token }}@github.com/liquibase/liquibase-ansible.git
             if [[ "${{ inputs.dry_run }}" == false ]]; then
-              git push "https://x-access-token:${{ steps.get-token.outputs.token }}@github.com/liquibase/liquibase-ansible.git" HEAD:main
+              git push
             else
                 echo "Dry run mode: changes have not been pushed."
             fi

--- a/.github/workflows/deploy-role.yml
+++ b/.github/workflows/deploy-role.yml
@@ -84,7 +84,7 @@ jobs:
             git commit -m "Update liquibase.version to ${{ inputs.version }}"
             git remote set-url origin https://x-access-token:${{ steps.get-token.outputs.token }}@github.com/liquibase/liquibase-ansible.git
             if [[ "${{ inputs.dry_run }}" == false ]]; then
-              git push
+              git push "https://${{ steps.get-token.outputs.token }}@github.com/liquibase/liquibase-ansible.git" HEAD:main
             else
                 echo "Dry run mode: changes have not been pushed."
             fi


### PR DESCRIPTION
This pull request updates the `.github/workflows/deploy-role.yml` file to enhance security by replacing the use of the default GitHub token with a GitHub App token for authentication. The most important changes include switching to the `actions/create-github-app-token` action and updating the Git remote URL to use the new token.

### Authentication Updates:
* Replaced the manual Git configuration step with the `actions/create-github-app-token@v2` action to generate a GitHub App token for authentication. This change uses the app ID and private key stored in secrets for secure token generation.
* Updated the `git remote set-url` command to use the newly generated GitHub App token (`steps.get-token.outputs.token`) instead of the default GitHub token for pushing changes.