### PR TITLE
DAT-20361   GitHub Secrets Migration

### DIFF
--- a/.github/workflows/deploy-role.yml
+++ b/.github/workflows/deploy-role.yml
@@ -2,6 +2,7 @@ name: Ansible Role Deploy
 
 permissions:
   contents: write
+  id-token: write # Required for OIDC authentication
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
This pull request updates the `.github/workflows/deploy-role.yml` file to enhance security and streamline the configuration process for accessing secrets and credentials. The most important changes include adding steps to configure AWS credentials and retrieve secrets from AWS Secrets Manager, as well as replacing `secrets` with `env` variables for sensitive data.

### Enhancements to AWS integration:
* Added a step to configure AWS credentials using the `aws-actions/configure-aws-credentials@v4` action for accessing the vault. (`[.github/workflows/deploy-role.ymlR45-R65](diffhunk://#diff-4e500aab22bc6be86961421a6198971069e43762ebcb00fd911e6b604b93c879R45-R65)`)
* Added a step to retrieve secrets from AWS Secrets Manager using the `aws-actions/aws-secretsmanager-get-secrets@v2` action, with support for JSON parsing. (`[.github/workflows/deploy-role.ymlR45-R65](diffhunk://#diff-4e500aab22bc6be86961421a6198971069e43762ebcb00fd911e6b604b93c879R45-R65)`)

### Security improvements:
* Replaced `secrets.LIQUIBASE_GITHUB_APP_ID` and `secrets.LIQUIBASE_GITHUB_APP_PRIVATE_KEY` with `env.LIQUIBASE_GITHUB_APP_ID` and `env.LIQUIBASE_GITHUB_APP_PRIVATE_KEY` for the GitHub App token configuration. (`[.github/workflows/deploy-role.ymlR45-R65](diffhunk://#diff-4e500aab22bc6be86961421a6198971069e43762ebcb00fd911e6b604b93c879R45-R65)`)
* Replaced `secrets.ANSIBLE_TOKEN` with `env.ANSIBLE_TOKEN` in the Ansible role import command to standardize the use of environment variables for sensitive data. (`[.github/workflows/deploy-role.ymlL94-R109](diffhunk://#diff-4e500aab22bc6be86961421a6198971069e43762ebcb00fd911e6b604b93c879L94-R109)`)