### PR TITLE
Fix DAT-22383: min_ansible_version format in main.yml

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
   galaxy_tags:
     - development
   license: Apache-2.0
-  min_ansible_version: 2.0
+  min_ansible_version: "2.0"
   platforms:
     - name: Alpine
       versions:


### PR DESCRIPTION
The import  logs here https://galaxy.ansible.com/ui/standalone/roles/liquibase/liquibase/import_log/ used `github_reference(branch)`: `main` and the "COMPUTING ROLE VERSIONS" section is empty :  no versions were detected.  

<img width="1872" height="703" alt="Screenshot 2026-03-13 at 11 01 41 AM" src="https://github.com/user-attachments/assets/63a6a4f5-acbd-4920-8200-bf0d3c4abeda" />


                                                                                                                                  
**Issue:**                                                                                                                                            

- Schema error blocking version detection: The import log shows: `$.galaxy_info.min_ansible_version` `2.0` is not of type 'string' . This needs to be a string, not a number 