### PR TITLE
DAT-22383: Update default Liquibase version to 5.0.2 in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ See [meta/requirements.yml](meta/requirements.yml)
 
 ## Role Variables
 
-* **liquibase_ver**: This property appears to specify the default version of Liquibase. **Default value** -> `4.26.0`
-* **liquibase_mirror**: This property specifies the default mirror or repository from which Liquibase releases can be downloaded. **Default value** -> `https://github.com/liquibase/liquibase/releases/download`
+* **liquibase_ver**: This property appears to specify the default version of Liquibase. **Default value** -> `5.0.2`
+* **liquibase_mirror**: This property specifies the default mirror or repository from which Liquibase releases can be downloaded. **Default value** -> `https://package.liquibase.com/downloads/oss/ansible`
 * **liquibase_parent_install_dir**: This property indicates the default parent installation directory for Liquibase. **Default value** -> `/usr/local`
 * **liquibase_checksums**: Checksums for different versions of Liquibase along with their respective download URLs. The checksums are SHA-256 hashes calculated for each Liquibase release file, ensuring the integrity of the downloaded files.
 
@@ -23,14 +23,14 @@ See [meta/requirements.yml](meta/requirements.yml)
     - role: liquibase.liquibase
 ```
 
-## Example Playbook (installs liquibase 4.26.0)
+## Example Playbook (installs liquibase 5.0.2)
 
 ```yml
 - hosts: server
   roles:
     - role: liquibase.liquibase
       liquibase_ver:
-        - 4.26.0
+        - 5.0.2
 ```
 
 ## Example Playbook installation process


### PR DESCRIPTION
This pull request updates the documentation in `README.md` to reflect the new default Liquibase version and download mirror. The changes ensure that users are guided to install Liquibase version 5.0.2 from the updated official download source.

**Documentation updates:**

* Updated the default value of `liquibase_ver` to `5.0.2` and `liquibase_mirror` to `https://package.liquibase.com/downloads/oss/ansible` in the role variables section to reflect the new version and mirror.
* Changed the example playbook to demonstrate installation of Liquibase 5.0.2 instead of 4.26.0.